### PR TITLE
Fixed wrong parameter name in description and alert message.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.eejsBlock_scripts = function (hook_name, args, cb) {
     var piwikString = "<script>alert('ep_piwik.url not set in settings.json, insert it in /admin/settings')</script>";
   }
   else if(!piwikSiteId) {
-    var piwikString = "<script>alert('ep_piwik.site_id not set in settings.json, insert it in /admin/settings')</script>";
+    var piwikString = "<script>alert('ep_piwik.siteId not set in settings.json, insert it in /admin/settings')</script>";
   }
   else {
     var piwikString = "<script type='text/javascript'>var _paq = _paq || [];_paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);(function() {var u=\"//" + piwikUrl + "/\";_paq.push(['setTrackerUrl', u+'piwik.php']);_paq.push(['setSiteId', " + piwikSiteId + "]);var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);})();</script>";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_piwik",
-  "description": "Add Piwik to Etherpad Lite -- IMPORTANT: Add the following to your settings.json file --   \"ep_piwik\":{\"url\":\"piwik.installation.com\",\"site_id\":\"1\"}",
+  "description": "Add Piwik to Etherpad Lite -- IMPORTANT: Add the following to your settings.json file --   \"ep_piwik\":{\"url\":\"piwik.installation.com\",\"siteId\":\"1\"}",
   "version": "0.0.4",
   "author": {
     "name": "Alexandre Girard",


### PR DESCRIPTION
We set the configuration accordingly to the description, but got an alert message. So I saw that the right parameter was named as "siteId" instead of "site_id".
